### PR TITLE
adds an api endpoint for all pizzerias

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ gem 'pry'
 gem 'json'
 gem 'geocoder'
 gem 'redcarpet'
+
+# For the API
+gem 'sinatra'
+gem 'sinatra-contrib'

--- a/api/v1/pizzerias.rb
+++ b/api/v1/pizzerias.rb
@@ -1,0 +1,26 @@
+require 'sinatra'
+require "sinatra/namespace"
+require 'json'
+
+namespace '/api' do
+  namespace '/v1' do
+    
+    get '/pizzerias' do
+      content_type :json
+      geojson_data.to_json
+    end
+
+    get '/pizzerias/:id' do
+      content_type :json
+      id = params[:id].to_i - 1
+      geojson_data['features'][id].to_json
+    end
+
+  end
+end
+
+private
+  def geojson_data
+    file = File.read('pizza_map.geojson')
+    JSON.parse(file)
+  end


### PR DESCRIPTION
### OVERVIEW

This PR adds an API endpoint with Sinatra so external client applications can use this data set. Basically, it grabs 'pizza_map.geojson', parses it to JSON and renders it to the endpoint.
### UPDATE

I just added a show API route, so you can grab pizzerias by id.
### HOW TO USE
- `bundle install` for any necessary gems
- fire up the API with `ruby api/v1/pizzerias.rb`
- to get back all pizzerias, hit this endpoint: http://localhost:4567/api/v1/pizzerias
- for a specific pizzeria, use something like this: http://localhost:4567/api/v1/pizzerias/some_pizzeria_id 
