### PR TITLE
add error handling on 404

### DIFF
--- a/api/v1/pizzerias.rb
+++ b/api/v1/pizzerias.rb
@@ -13,7 +13,12 @@ namespace '/api' do
     get '/pizzerias/:id' do
       content_type :json
       id = params[:id].to_i - 1
-      geojson_data['features'][id].to_json
+      json = geojson_data['features'][id].to_json
+      if json == 'null'
+        raise Sinatra::NotFound
+      else
+        json
+      end
     end
 
     get '/properties/search' do
@@ -23,7 +28,6 @@ namespace '/api' do
 
       valid_query? ? return_search_results.to_json : []
     end
-
 
   end
 end


### PR DESCRIPTION
I'm using this awesome repo to demo some load testing tools and I wanted
to be able to simulate what happens when I get an error. Currently, the
API returns a 200 (but null) when you reference an id that doesn't exist
(currently > 114).
