### PR TITLE
adds rack configuration to api for cross origin request sharing

### DIFF
--- a/api/v1/pizzerias.rb
+++ b/api/v1/pizzerias.rb
@@ -1,13 +1,23 @@
 require 'sinatra'
-require "sinatra/namespace"
+require 'sinatra/namespace'
+require 'sinatra/cross_origin'
 require 'json'
+
+class API < Sinatra::Base
+
+configure do
+  register Sinatra::Namespace
+  register Sinatra::CrossOrigin
+end
+
+enable :cross_origin
 
 namespace '/api' do
   namespace '/v1' do
-    
+
     get '/pizzerias' do
       content_type :json
-      geojson_data.to_json
+      geojson_data['features'].to_json
     end
 
     get '/pizzerias/:id' do
@@ -44,3 +54,4 @@ private
   def return_search_results
     @pizzerias.select{ |pizzeria| pizzeria['properties'][@query].downcase == params[@query].downcase}
   end
+end

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,3 @@
+require './api/v1/pizzerias'
+
+run API

--- a/using_the_api.md
+++ b/using_the_api.md
@@ -1,8 +1,8 @@
 # USING THE API
 
 ### UP & RUNNING
-run `ruby api/v1/pizzerias.rb`
-This is a Sinatra API, so it will run locally on `http://localhost:4567`.
+run `rackup`
+This is a Rack API, so it will run locally on `http://localhost:9292`.
 Attach the endpoint you want to that url to get back info.
 
 ### USING THE ENDPOINTS


### PR DESCRIPTION
Adds Rack to Sinatra API. Allows for CORS (Cross Origin Request Sharing) for client-side applications. Basically, client-side apps can make ajax requests now, and you can fire up the API by just running `rackup`
